### PR TITLE
Include Payload with Autocompleter Suggestion

### DIFF
--- a/redisearch/autocomplete.go
+++ b/redisearch/autocomplete.go
@@ -40,7 +40,13 @@ func (a *Autocompleter) AddTerms(terms ...Suggestion) error {
 
 	i := 0
 	for _, term := range terms {
-		if err := conn.Send("FT.SUGADD", a.name, term.Term, term.Score); err != nil {
+
+		args := redis.Args{a.name, term.Term, term.Score}
+		if payload := term.Payload; payload != "" {
+			args = append(args, "PAYLOAD", payload)
+		}
+
+		if err := conn.Send("FT.SUGADD", args...); err != nil {
 			return err
 		}
 		i++
@@ -60,27 +66,38 @@ func (a *Autocompleter) AddTerms(terms ...Suggestion) error {
 // Suggest gets completion suggestions from the Autocompleter dictionary to the given prefix.
 // If fuzzy is set, we also complete for prefixes that are in 1 Levenshten distance from the
 // given prefix
-func (a *Autocompleter) Suggest(prefix string, num int, fuzzy bool) ([]Suggestion, error) {
+func (a *Autocompleter) Suggest(prefix string, num int, fuzzy, withPayloads bool) ([]Suggestion, error) {
 	conn := a.pool.Get()
 	defer conn.Close()
+
+	inc := 2
 
 	args := redis.Args{a.name, prefix, "MAX", num, "WITHSCORES"}
 	if fuzzy {
 		args = append(args, "FUZZY")
+	}
+	if withPayloads {
+		args = append(args, "WITHPAYLOADS")
+		inc = 3
 	}
 	vals, err := redis.Strings(conn.Do("FT.SUGGET", args...))
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]Suggestion, 0, len(vals)/2)
-	for i := 0; i < len(vals); i += 2 {
+	ret := make([]Suggestion, 0, len(vals)/inc)
+	for i := 0; i < len(vals); i += inc {
 
 		score, err := strconv.ParseFloat(vals[i+1], 64)
 		if err != nil {
 			continue
 		}
-		ret = append(ret, Suggestion{Term: vals[i], Score: score})
+
+		suggestion := Suggestion{Term: vals[i], Score: score}
+		if withPayloads {
+			suggestion.Payload = vals[i+2]
+		}
+		ret = append(ret, suggestion)
 
 	}
 


### PR DESCRIPTION
The inclusion of this Pull Request will allow users to add Suggestions to the Autocompleter with a Payload attached. Users will also be able to retrieve the attached payload with the Suggest function, if passing withPayloads=true.

Note: The inclusion of the 'withPayloads' variable will require an update to the documentation to reflect the new structure. http://redisearch.io/go_client/#func%22_%22autocompleter%22_%22suggest